### PR TITLE
fix(timer): reset button now correctly resets the timer

### DIFF
--- a/src/QuizContext.jsx
+++ b/src/QuizContext.jsx
@@ -50,6 +50,7 @@ export const QuizProvider = ({ children }) => {
     setIsSend(false);
     setUserAnswers(new Array(questions.length));
     setScore(0);
+    setTimeLeft(DURATION);
   };
 
   // Shuffle array
@@ -67,20 +68,14 @@ export const QuizProvider = ({ children }) => {
     <QuizContext.Provider
       value={{
         score,
-
         isSend,
-
         userAnswers,
-
         addUserAnswers,
-
         sendQuiz,
-
         onReset,
         timeLeft,
         setTimeLeft,
         timerRef,
-
         questions,
       }}
     >


### PR DESCRIPTION
Bug Fix: Reset button did not reset the timer

Problem:

After a faulty merge from the feature/timer branch, the reset button stopped resetting the timer — it continued counting from the paused value.

Solution:

Added a single line of code to properly reset the timer value on reset,
Removed a few unnecessary blank lines from the context component (QuizContext.jsx) for clarity.

Tested:

Verified manually that the timer now restarts from the beginning when the Reset button is clicked,
Start, send, and reset functionalities are all working correctly in the browser.

Note:

This fix is implemented in a clean branch (bugFix/fix-timer) created after discarding the faulty merge. All code is now stable and verified.

